### PR TITLE
refactor/customer-menu-page

### DIFF
--- a/src/components/customer-header/CustomerHeaderDrawer.vue
+++ b/src/components/customer-header/CustomerHeaderDrawer.vue
@@ -26,14 +26,16 @@ const visible = computed({
   get: () => props.isDrawerOpen,
   set: () => props.handleDrawerClose()
 })
+const navHeightStyle = computed(() => `${props.navHeight}px`)
 </script>
 <template>
   <Drawer
     v-model:visible="visible"
     :showCloseIcon="false"
     pt:header:class="hidden"
-    :pt:root:class="`max-w-[305px] border-none top-[${navHeight}px]`"
+    pt:root:class="max-w-[305px] border-none"
     pt:content:class="px-0"
+    :style="{ top: navHeightStyle }"
   >
     <ul class="flex flex-col">
       <li
@@ -46,4 +48,4 @@ const visible = computed({
     </ul>
   </Drawer>
 </template>
-<style scoped></style>
+<style lang="scss"></style>

--- a/src/components/customer-header/CustomerHeaderList.vue
+++ b/src/components/customer-header/CustomerHeaderList.vue
@@ -8,12 +8,6 @@ const listData = ref([
   { name: '蛋糕', url: '/customer/menu/cake' },
   { name: '其他點心', url: '/customer/menu/otherDessert' }
 ])
-defineProps({
-  isHeaderListFixed: {
-    type: String,
-    default: ''
-  }
-})
 defineExpose({
   ulDom: ulDom
 })
@@ -22,7 +16,6 @@ defineExpose({
   <ul
     ref="ulDom"
     class="flex items-center p-3 gap-x-6 transition-all overflow-x-auto whitespace-nowrap scrollbar-hide max-w-screen-sm"
-    :class="isHeaderListFixed"
   >
     <li class="flex-grow" v-for="listItem in listData" :key="listItem.name">
       <RouterLink class="pb-1" :to="listItem.url" exact-active-class="link-active">

--- a/src/components/customer-header/CustomerHeaderNav.vue
+++ b/src/components/customer-header/CustomerHeaderNav.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, useTemplateRef } from 'vue'
 import Button from 'primevue/button'
-const nav = useTemplateRef('nav') //3.5的新api， 但3.4就有了，不確定功能是否一致
+const navDom = useTemplateRef('navDom') //3.5的新api， 但3.4就有了，不確定功能是否一致
 const props = defineProps({
   handleDrawerOpen: {
     type: Function,
@@ -17,7 +17,7 @@ const navigationButtons = ref([
     icon: 'pi pi-bars',
     label: '導覽列',
     onClick: () => {
-      props.getNavHeight(nav.value.clientHeight)
+      props.getNavHeight(navDom.value.clientHeight)
       props.handleDrawerOpen()
     },
     liClass: ''
@@ -40,11 +40,11 @@ const navigationButtons = ref([
   }
 ])
 defineExpose({
-  nav: nav
+  navDom: navDom
 })
 </script>
 <template>
-  <nav ref="nav" class="p-3 bg-primary-700">
+  <nav ref="navDom" class="p-3 bg-primary-700">
     <ul class="flex gap-x-4 items-center">
       <li v-for="button in navigationButtons" :key="button.label" :class="button.liClass">
         <Button

--- a/src/layout/CustomerContainer.vue
+++ b/src/layout/CustomerContainer.vue
@@ -1,6 +1,6 @@
 <script setup></script>
 <template>
-  <div class="w-full max-w-screen-sm min-h-screen mx-auto bg-white relative">
+  <div class="w-full max-w-screen-sm min-h-screen mx-auto bg-primary-50 relative">
     <slot name="header"></slot>
     <main>
       <slot></slot>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import CustomerPage from '@/views/CustomerPage.vue'
+import CustomerMenuPage from '@/views/CustomerMenuPage.vue'
 import HomeView from '../views/HomePage.vue'
 
 const router = createRouter({
@@ -13,12 +15,12 @@ const router = createRouter({
     {
       path: '/customer',
       name: 'Customer',
-      component: () => import('@/views/CustomerPage.vue')
+      component: CustomerPage
     },
     {
       path: '/customer/menu',
       name: 'CustomerMenu',
-      component: () => import('@/views/CustomerMenuPage.vue'),
+      component: CustomerMenuPage,
       children: [
         {
           path: 'italianCoffee',

--- a/src/views/CustomerMenuPage.vue
+++ b/src/views/CustomerMenuPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useScroll } from '@vueuse/core'
 import CustomerContainer from '@/layout/CustomerContainer.vue'
 import CustomerHeaderNav from '@/components/customer-header/CustomerHeaderNav.vue'
@@ -13,21 +13,21 @@ const headerInfoExpose = ref(null) //取得子組件暴露給父組件的本身d
 const headerListExpose = ref(null) //取得子組件暴露給父組件的本身dom
 const headerInputExpose = ref(null) //取得子組件暴露給父組件的本身dom
 const isDrawerOpen = ref(false) //控制Drawer的開啟&關閉
-const navHeight = ref(0) //CustomerHeaderNav組件的 dom高度，此處是給CustomerHeaderDrawer組件使用
 const isHeaderNavFixed = computed(() => {
   if (y.value > 0) {
-    return 'fixed w-full z-10'
+    return 'fixed w-full z-10 max-w-screen-sm'
   } else {
     return ''
   }
 })
+const getNavHeight = computed(() => headerNavExpose.value?.navDom.clientHeight || 0)
 const isHeaderListFixed = computed(() => {
   const infoHeight = headerInfoExpose.value?.infoDom.clientHeight || 0
   const inputHeight = headerInputExpose.value?.inputDom.clientHeight || 0
-  const navHeight = headerNavExpose.value?.nav.clientHeight || 0
+  const navHeight = headerNavExpose.value?.navDom.clientHeight || 0
   const totalHeight = infoHeight + inputHeight
-  if (y.value >= totalHeight) {
-    return `fixed w-full z-10 top-[${navHeight}px]`
+  if (y.value >= totalHeight - navHeight) {
+    return `fixed  w-full z-10 `
   } else {
     return ''
   }
@@ -38,29 +38,29 @@ const handleDrawerOpen = () => {
 const handleDrawerClose = () => {
   isDrawerOpen.value = false
 }
-const getNavHeight = (value) => {
-  navHeight.value = value
-}
 </script>
 <template>
-  <CustomerContainer class="bg-primary-50">
+  <CustomerContainer>
     <template #header>
       <header>
         <CustomerHeaderNav
           ref="headerNavExpose"
           :handleDrawerOpen="handleDrawerOpen"
-          :getNavHeight="getNavHeight"
           :class="isHeaderNavFixed"
         />
         <CustomerHeaderDrawer
-          :navHeight="navHeight"
+          :navHeight="getNavHeight"
           :isDrawerOpen="isDrawerOpen"
           :handleDrawerClose="handleDrawerClose"
           v-model:isDrawerOpen="isDrawerOpen"
         />
         <CustomHeaderInfo ref="headerInfoExpose" />
         <CustomerHeaderInput ref="headerInputExpose" />
-        <CustomerHeaderList ref="headerListExpose" :isHeaderListFixed="isHeaderListFixed" />
+        <CustomerHeaderList
+          ref="headerListExpose"
+          :class="isHeaderListFixed"
+          :style="{ top: getNavHeight + 'px' }"
+        />
       </header>
     </template>
     <template #default>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 export default defineConfig({
   plugins: [
     vue(),
-    vueDevTools(),
+    // vueDevTools(),
   ],
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
1.利用 defineExpose 將子組件的 dom元素屬性 暴露給父組件使用
2.父組件利用暴露的子組件dom屬性，去取得子組件dom元素的高度( 可以寫死，但我想動態獲取 )
3.上面流程是上一個分支，所做的內容之一，但可能 優先級問題?(不確定)，導致使用 :class = `fixed w-full z-10 top-[${navHeight}px]` 方式，會造成取得高度失敗使得樣式沒有如預期實現，使用 :style方式，去實現樣式
